### PR TITLE
Fix incomplete Node errors

### DIFF
--- a/include/scriptingEvaluator.h
+++ b/include/scriptingEvaluator.h
@@ -17,6 +17,7 @@ As long as this comment is preserved at the top of the file
 #pragma once
 
 #include <iostream>
+#include <cmath>
 
 #include "scriptingNodes.h"
 #include "scriptingScenarios.h"
@@ -132,7 +133,7 @@ public:
     }
 	void visit(const NodePow& node)
 	{ 
-        visitBinary(node, [](T& x, const T y) { x = pow(x, y); });
+        visitBinary(node, [](T& x, const T y) { x = std::pow(x, y); });
     }
     void visit(const NodeMax& node)
     {
@@ -163,11 +164,11 @@ public:
 	//	Functions
 	void visit(const NodeLog& node)
 	{
-        visitUnary(node, [](T& x) { x = log(x); });
+        visitUnary(node, [](T& x) { x = std::log(x); });
     }
 	void visit(const NodeSqrt& node)
 	{
-        visitUnary(node, [](T& x) { x = sqrt(x); });
+        visitUnary(node, [](T& x) { x = std::sqrt(x); });
     }
 
     //  Multies

--- a/include/scriptingFuzzyEval.h
+++ b/include/scriptingFuzzyEval.h
@@ -17,6 +17,7 @@ As long as this comment is preserved at the top of the file
 #pragma once
 
 #include "scriptingEvaluator.h"
+#include <cmath>
 
 #define EPS 1.0e-12
 #define ONEMINUSEPS 0.999999999999
@@ -75,7 +76,7 @@ class FuzzyEvaluator : public EvaluatorBase<T, FuzzyEvaluator>
 		const double halfEps = 0.5 * eps;
 
 		if (x < - halfEps || x > halfEps) return 0.0;
-		else return ( halfEps - fabs( x)) / halfEps;
+		else return ( halfEps - std::fabs( x)) / halfEps;
 	}
 
 	//	Butterfly (lb,0,rb)

--- a/include/scriptingNodes.h
+++ b/include/scriptingNodes.h
@@ -282,3 +282,5 @@ ExprTree make_base_binary(ExprTree &lhs, ExprTree &rhs)
     //	Return
     return top;
 }
+
+#include "scriptingVisitorImpl.h"

--- a/include/scriptingVisitor.h
+++ b/include/scriptingVisitor.h
@@ -29,29 +29,13 @@ struct Visitor
 {
     //  Visit a node with concrete visitor
     //      use this to hide the statc_cast
-    void visitNode(Node &node)
-    {
-        //  static_cast : visit as concrete visitor
-        node.accept(static_cast<V &>(*this));
-    }
+    void visitNode(Node &node);
 
     //  Visit all the arguments with concrete (type V) visitor
-    void visitArguments(Node &node)
-    {
-        for (auto &arg : node.arguments)
-        {
-            //  static_cast : visit as concrete visitor
-            arg->accept(static_cast<V &>(*this));
-        }
-    }
+    void visitArguments(Node &node);
 
     //  Default catch all = visit arguments
-    void visit(Node &node)
-    {
-        //  V does not declare a visit to that node type,
-        //      either const or non const - fall back to default visit arguments
-        visitArguments(node);
-    }
+    void visit(Node &node);
 };
 
 //  Const visitor
@@ -59,31 +43,12 @@ struct Visitor
 template <class V>
 struct constVisitor
 {
-    void visitNode(const Node &node)
-    {
-        //  static_cast : visit as concrete visitor
-        node.accept(static_cast<V &>(*this));
-    }
+    void visitNode(const Node &node);
 
-    void visitArguments(const Node &node)
-    {
-        for (const auto &arg : node.arguments)
-        {
-            //  static_cast : visit as visitor of type V
-            arg->accept(static_cast<V &>(*this));
-        }
-    }
+    void visitArguments(const Node &node);
 
     template <class NODE>
-    void visit(const NODE &node)
-    {
-        //  Const visitors cannot declare non const visits: we check that and produce a compilation error
-        static_assert(!hasNonConstVisit<V>::template forNodeType<NODE>(), "CONST VISITOR DECLARES A NON-CONST VISIT");
-
-        //  V does not declare a visit to that node type,
-        //      either const or non const - fall back to visiting arguments
-        visitArguments(node);
-    }
+    void visit(const NODE &node);
 };
 
 //  Visitable classes

--- a/include/scriptingVisitorImpl.h
+++ b/include/scriptingVisitorImpl.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "scriptingVisitor.h"
+
+//  Implementation of Visitor and constVisitor functions that require the Node definition
+
+template <class V>
+inline void Visitor<V>::visitNode(Node &node)
+{
+    node.accept(static_cast<V &>(*this));
+}
+
+template <class V>
+inline void Visitor<V>::visitArguments(Node &node)
+{
+    for (auto &arg : node.arguments)
+    {
+        arg->accept(static_cast<V &>(*this));
+    }
+}
+
+template <class V>
+inline void Visitor<V>::visit(Node &node)
+{
+    visitArguments(node);
+}
+
+template <class V>
+inline void constVisitor<V>::visitNode(const Node &node)
+{
+    node.accept(static_cast<V &>(*this));
+}
+
+template <class V>
+inline void constVisitor<V>::visitArguments(const Node &node)
+{
+    for (const auto &arg : node.arguments)
+    {
+        arg->accept(static_cast<V &>(*this));
+    }
+}
+
+template <class V>
+template <class NODE>
+inline void constVisitor<V>::visit(const NODE &node)
+{
+    static_assert(!hasNonConstVisit<V>::template forNodeType<NODE>(),
+                  "CONST VISITOR DECLARES A NON-CONST VISIT");
+    visitArguments(node);
+}


### PR DESCRIPTION
## Summary
- separate visitor implementations from declarations to avoid incomplete type errors
- add missing `<cmath>` and use `std::` math functions

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68473c99e3ec832d8fc47cffc3c9ed4c